### PR TITLE
Fix double scroll bars

### DIFF
--- a/fs-artifacts.html
+++ b/fs-artifacts.html
@@ -110,6 +110,7 @@ Example:
 
       iron-list {
         height: 100vh;
+        overflow-y: inherit !important;
         --iron-list-items-container: {
           padding-bottom: 60px;
         };


### PR DESCRIPTION
Disabled the auto scroll on iron-list to allow a parent to control the scrolling