### PR TITLE
Show loading spinner when loading cached data

### DIFF
--- a/fs-artifacts.html
+++ b/fs-artifacts.html
@@ -328,7 +328,7 @@ Example:
     <birch-popover viewport-positioning id="popover"></birch-popover>
     <div id='header' class$='{{_viewTypeClass(listView)}} scrollContainer'>
       <div class="p-header" slot="header">
-        <i class='loading-icon' hidden='[[_hideLoading(loadingData, loadingView, artifacts)]]'></i>
+        <i class='loading-icon' hidden='[[_hideLoading(loadingData, loadingView)]]'></i>
         <div id="album-display-container" hidden='[[!album.id]]'>
           <fs-album-display data-test='album-info'
             logged-out='[[readOnly]]'
@@ -788,10 +788,8 @@ Example:
       if (this.readOnly) return;
       this.fire('toggleUploadDrag', { 'disable' : false });
     },
-    _hideLoading: function(loadingData, loadingView, artifacts) {
-      if (!loadingView && artifacts && artifacts.length) return true;
-      if (loadingView) return false;
-      return !loadingData;
+    _hideLoading: function(loadingData, loadingView) {
+      return !loadingData && !loadingView;
     },
     _readOnlyAlbum: function(readOnly, editableByCaller) {
       return readOnly || !editableByCaller;


### PR DESCRIPTION
### Changes
- Show loading spinner when loading cached data.
  - `fs-artifact-selector` waits a little longer now before showing cached artifacts, so the spinner is now shown briefly when loading cached data.  See [fs-artifact-selector PR #29](https://github.com/fs-webdev/fs-artifact-selector/pull/29) for more details.