### PR TITLE
(DO NOT MERGE) Fixing empty gallery instructions

### DIFF
--- a/fs-artifacts.html
+++ b/fs-artifacts.html
@@ -331,7 +331,7 @@ Example:
     <div id='header' class$='{{_viewTypeClass(listView)}} scrollContainer'>
       <div class="p-header" slot="header">
         <i class='loading-icon' hidden='[[_hideLoading(loadingData, loadingView)]]'></i>
-        <div id="album-display-container">
+        <div id="album-display-container" hidden='[[!album.id]]'>
           <fs-album-display data-test='album-info'
             logged-out='[[readOnly]]'
             read-only='[[_readOnlyAlbum(readOnly, album.editableByCaller)]]'
@@ -340,8 +340,7 @@ Example:
             artifacts='{{artifacts}}'
             list-view='[[listView]]'
             show-owner='[[showAlbumOwner]]'
-            on-edit-album='_handleDataChange'
-            hidden='[[!album.id]]'></fs-album-display>
+            on-edit-album='_handleDataChange'></fs-album-display>
           <div id="empty-album-notification" hidden='[[artifacts.length]]'>
             <i hidden='{{_hideIfEitherArgTrue(mobile, readOnly)}}' class="empty-album-image"></i>
             <div class='text-wrap'>

--- a/fs-artifacts.html
+++ b/fs-artifacts.html
@@ -390,10 +390,10 @@ Example:
             <i hidden='{{_hideIfEitherArgTrue(mobile, readOnly)}}' class="empty-album-image"></i>
             <div class='text-wrap'>
               <p hidden='[[_hideIfEitherArgTrue(mobile, readOnly)]]'>
-                [[i18n('text')]]
+                [[i18n('text-collection')]]
               </p>
               <p hidden='[[_hideIfEitherArgFalseTrue(mobile, readOnly)]]'>
-                [[i18n('text-mobile')]]
+                [[i18n('text-mobile-collection')]]
               </p>
             </div>
           </div>
@@ -403,10 +403,10 @@ Example:
             <i hidden='{{_hideIfEitherArgTrue(mobile, readOnly)}}' class="empty-album-image"></i>
             <div class='text-wrap'>
               <p hidden='[[_hideIfEitherArgTrue(mobile, readOnly)]]'>
-                [[i18n('text')]]
+                [[i18n('text-collection')]]
               </p>
               <p hidden='[[_hideIfEitherArgFalseTrue(mobile, readOnly)]]'>
-                [[i18n('text-mobile')]]
+                [[i18n('text-mobile-collection')]]
               </p>
             </div>
           </div>

--- a/fs-artifacts.html
+++ b/fs-artifacts.html
@@ -129,6 +129,22 @@ Example:
         margin-bottom: 50px;
       }
 
+      #empty-gallery-notification {
+        position: relative;
+        text-align: center;
+        width: 100%;
+        margin-top: 20px;
+        margin-bottom: 50px;
+      }
+
+      #empty-favorites-notification {
+        position: relative;
+        text-align: center;
+        width: 100%;
+        margin-top: 20px;
+        margin-bottom: 50px;
+      }
+
       .text-wrap {
         text-align: center;
         margin: 20px auto 0;
@@ -367,6 +383,32 @@ Example:
           <div id="missing-album-header">
             <h5>[[i18n('missing_album')]]</h5>
             <button class="fs-button fs-button--recommended" on-click="_handleGoToMemories">[[i18n('go-to-memories')]]</button>
+          </div>
+        </div>
+        <div id="gallery-header" hidden="[[!_same(view, 'my-memories')]]">
+          <div id="empty-gallery-notification" hidden='[[artifacts.length]]'>
+            <i hidden='{{_hideIfEitherArgTrue(mobile, readOnly)}}' class="empty-album-image"></i>
+            <div class='text-wrap'>
+              <p hidden='[[_hideIfEitherArgTrue(mobile, readOnly)]]'>
+                [[i18n('text')]]
+              </p>
+              <p hidden='[[_hideIfEitherArgFalseTrue(mobile, readOnly)]]'>
+                [[i18n('text-mobile')]]
+              </p>
+            </div>
+          </div>
+        </div>
+        <div id="favorites-header" hidden="[[!_same(view, 'my-favorites')]]">
+          <div id="empty-favorites-notification" hidden='[[artifacts.length]]'>
+            <i hidden='{{_hideIfEitherArgTrue(mobile, readOnly)}}' class="empty-album-image"></i>
+            <div class='text-wrap'>
+              <p hidden='[[_hideIfEitherArgTrue(mobile, readOnly)]]'>
+                [[i18n('text')]]
+              </p>
+              <p hidden='[[_hideIfEitherArgFalseTrue(mobile, readOnly)]]'>
+                [[i18n('text-mobile')]]
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/fs-artifacts.html
+++ b/fs-artifacts.html
@@ -331,7 +331,7 @@ Example:
     <div id='header' class$='{{_viewTypeClass(listView)}} scrollContainer'>
       <div class="p-header" slot="header">
         <i class='loading-icon' hidden='[[_hideLoading(loadingData, loadingView)]]'></i>
-        <div id="album-display-container" hidden='[[!album.id]]'>
+        <div id="album-display-container">
           <fs-album-display data-test='album-info'
             logged-out='[[readOnly]]'
             read-only='[[_readOnlyAlbum(readOnly, album.editableByCaller)]]'
@@ -340,7 +340,8 @@ Example:
             artifacts='{{artifacts}}'
             list-view='[[listView]]'
             show-owner='[[showAlbumOwner]]'
-            on-edit-album='_handleDataChange'></fs-album-display>
+            on-edit-album='_handleDataChange'
+            hidden='[[!album.id]]'></fs-album-display>
           <div id="empty-album-notification" hidden='[[artifacts.length]]'>
             <i hidden='{{_hideIfEitherArgTrue(mobile, readOnly)}}' class="empty-album-image"></i>
             <div class='text-wrap'>

--- a/fs-artifacts.html
+++ b/fs-artifacts.html
@@ -385,21 +385,8 @@ Example:
             <button class="fs-button fs-button--recommended" on-click="_handleGoToMemories">[[i18n('go-to-memories')]]</button>
           </div>
         </div>
-        <div id="gallery-header" hidden="[[!_same(view, 'my-memories')]]">
+        <div id="gallery-header" hidden="[[!_isMemoriesOrFavorites(view)]]">
           <div id="empty-gallery-notification" hidden='[[artifacts.length]]'>
-            <i hidden='{{_hideIfEitherArgTrue(mobile, readOnly)}}' class="empty-album-image"></i>
-            <div class='text-wrap'>
-              <p hidden='[[_hideIfEitherArgTrue(mobile, readOnly)]]'>
-                [[i18n('text-collection')]]
-              </p>
-              <p hidden='[[_hideIfEitherArgFalseTrue(mobile, readOnly)]]'>
-                [[i18n('text-mobile-collection')]]
-              </p>
-            </div>
-          </div>
-        </div>
-        <div id="favorites-header" hidden="[[!_same(view, 'my-favorites')]]">
-          <div id="empty-favorites-notification" hidden='[[artifacts.length]]'>
             <i hidden='{{_hideIfEitherArgTrue(mobile, readOnly)}}' class="empty-album-image"></i>
             <div class='text-wrap'>
               <p hidden='[[_hideIfEitherArgTrue(mobile, readOnly)]]'>
@@ -711,6 +698,9 @@ Example:
       this.unlisten(document, 'list-item-mouseout', '_handleListItemMouseout');
       // this.unlisten(document, 'open-restricted-info', '_handleRestrictedInfo');
       this.unlisten(document, 'update-artifacts-list', 'updateList');
+    },
+    _isMemoriesOrFavorites: function(view) {
+      return (view === 'my-memories' || view === 'my-favorites'); 
     },
     _same: function(a, b) {
       return a === b;

--- a/locales/fs-artifacts_en.json
+++ b/locales/fs-artifacts_en.json
@@ -2,6 +2,8 @@
   "title":"Start Collecting Memories",
   "text":"Click on the green plus to add memories to this album, or drag and drop memories into the album.",
   "text-mobile":"Click on the green plus to add memories to this album, or select memories from a different album.",
+  "text-collection":"Click on the green plus to add memories to this collection, or drag and drop memories into the collection.",
+  "text-mobile-collection":"Click on the green plus to add memories to this collection, or select memories from a different collection.",
   "unauth-text":"There are no memories of this type.",
   "no-album":"This album no longer exists.",
   "go-to-memories": "Go to My Memories",


### PR DESCRIPTION
## Moved Check For Album ID

- This check was checking to see if a user was in an album or not
  - This encompassed both the album display and the message
- I moved it to only check to display the album and not to check for the message
  - The message is supposed to be used on all pages that do not have artifacts, not just albums