### PR TITLE
Fix gallery load

### DIFF
--- a/fs-artifacts.html
+++ b/fs-artifacts.html
@@ -859,7 +859,6 @@ Example:
       // Poll Dom to signal when to display it and turn off spinner.
       var pollDom = setInterval(function() {
         if (!this.isDebouncerActive('fs-artifacts-view-change')) {
-          this.loadingView = false;
           clearInterval(pollDom);
           this.unlisten(this.$.header, 'dom-change', '_handleViewDomChange');
           if (!this._domInitialLoad) this.fire('dom-loaded');

--- a/fs-artifacts.html
+++ b/fs-artifacts.html
@@ -849,7 +849,6 @@ Example:
       // what has been rendered.
       setTimeout(function(){
         clearInterval(pollDom);
-        this.loadingView = false;
         this.unlisten(this.$.header, 'dom-change', '_handleViewDomChange');
         if (!this._domInitialLoad) this.fire('dom-loaded');
         this._domInitialLoad = true;


### PR DESCRIPTION
### Keep Spinner Until Artifacts Have Returned

- Setting to false at these points would stop the spinner too early. 
  - Tested on gallery with 3000 artifacts and one with 0 and it still works correctly